### PR TITLE
Map index title

### DIFF
--- a/src/main/java/org/olf/folio/order/entities/inventory/Instance.java
+++ b/src/main/java/org/olf/folio/order/entities/inventory/Instance.java
@@ -16,6 +16,7 @@ public class Instance extends FolioEntity {
   public static final String P_ID = "id";
   public static final String P_HRID = "hrid";
   public static final String P_TITLE = "title";
+  public static final String P_INDEX_TITLE = "indexTitle";
   public static final String P_SOURCE = "source";
   public static final String P_INSTANCE_TYPE_ID = "instanceTypeId";
   public static final String P_IDENTIFIERS = "identifiers";
@@ -37,6 +38,9 @@ public class Instance extends FolioEntity {
   }
   public Instance putTitle(String title) {
     return (Instance) putString(P_TITLE, title);
+  }
+  public Instance putIndexTitle(String indexTitle) {
+    return (Instance) putString(P_INDEX_TITLE, indexTitle);
   }
   public Instance putSource(String source) {
     return (Instance) putString(P_SOURCE, source);

--- a/src/main/java/org/olf/folio/order/mapping/MarcToFolio.java
+++ b/src/main/java/org/olf/folio/order/mapping/MarcToFolio.java
@@ -845,6 +845,7 @@ public abstract class MarcToFolio {
 
   public void populateInstance(Instance instance) throws Exception {
     instance.putTitle(title())
+            .putIndexTitle(Utils.makeIndexTitle(title()))
             .putSource(Instance.V_FOLIO)
             .putInstanceTypeId(FolioData.getInstanceTypeId(Instance.INSTANCE_TYPE))
             .putIdentifiers(instanceIdentifiers())

--- a/src/main/java/org/olf/folio/order/utils/Utils.java
+++ b/src/main/java/org/olf/folio/order/utils/Utils.java
@@ -2,7 +2,56 @@ package org.olf.folio.order.utils;
 
 import org.folio.isbn.IsbnUtil;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+
 public class Utils {
+  private static final List<String> articles = Arrays.asList(
+          "a ", "a'", "al ", "al-", "am ", "an ", "an t-", "ane ", "ang ", "ang mga ", "as ", "az ",
+          "bat ", "bir ", "d'", "da ", "das ",
+          "de ", "dei ", "dem ", "den ", "der ", "des ", "det ", "di ", "die ", "dos ",
+          "e ", "'e ", "een ", "eene ", "egy ", "ei ", "ein ", "eine ", "einem ", "einen ",
+          "einer ", "eines ", "eit ", "el ", "el-", "els ", "en ", "enne ", "et ", "ett ", "eyn ", "eyne ",
+          "gl'", "gli ",
+          "ha-", "hai ", "he ", "hē ", "he-", "heis ", "hen ", "hena ", "henas ", "het ", "hin ",
+          "hina ", "hinar ", "hinir ", "hinn ", "hinna ", "hinnar ", "hinni ", "hins ", "hinu ",
+          "hinum ", "hið ", "ho ", "hoi ",
+          "i ", "ih'", "il ", "il-", "in ", "it ",
+          "ka ", "ke ",
+          "l'", "l-", "la ", "las ", "le ", "les ", "lh ", "lhi ", "li ", "lis ", "lo ", "los ",
+          "lou ", "lu ",
+          "mga ", "mia ",
+          "'n ", "na ", "na h-", "njē ", "ny ",
+          "'o ", "o ", "os ",
+          "'r ",
+          "'s ",
+          "'t ", "ta ", "tais ", "tas ", "tē ", "tēn ", "tēs ", "the ", "to ", "tō ", "tois ",
+          "ton ", "tōn ", "tou ",
+          "um ", "uma ", "un ", "un'", "una ", "une ", "unei ", "unha ", "uno ", "uns ", "unui ",
+          "us ",
+          "y ", "ye ", "yr ");
+
+  static {
+    // When removing article, consider "an -t" before "an , "ang mga " before "ang " etc
+    Collections.reverse(articles);
+  }
+
+  /**
+   * Removes initial articles from title, case-insensitively.
+   * @param title to remove article from
+   * @return title without the initial article if any
+   */
+  public static String makeIndexTitle (String title) {
+    for (String article : articles) {
+      if (title.toLowerCase().startsWith(article)) {
+        return title.replaceFirst("(?i)"+article,"");
+      }
+    }
+    return title;
+  }
+
   public static boolean isInvalidIsbn (String isbn) {
     return !isValidIsbn(isbn);
   }


### PR DESCRIPTION
UC has requested that the title is mapped to indexTitle as well, but with any initial article removed as per https://www.loc.gov/marc/bibliographic/bdapndxf.html

I've understood that the request has to do with issues in searching for titles in the new Kiwi release due to the shift to Elastic Search and the treatment of initial articles there.
 
I suppose other organizations might find the change useful too, or at least find it acceptable, so I'm proposing this a general mapping change. 