### PR TITLE
Pin jetty versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,17 +34,17 @@
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-server</artifactId>
-			<version>[9.4.41,)</version>
+			<version>${jettyVersion}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-webapp</artifactId>
-			<version>[9.4.33,)</version>
+			<version>${jettyVersion}</version>
 		</dependency>
 		<dependency>
 			<groupId>org.eclipse.jetty</groupId>
 			<artifactId>jetty-servlets</artifactId>
-			<version>[9.4.41,)</version>
+			<version>${jettyVersion}</version>
 		</dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
 - Unpinned versions caused ewer versions to be pulled in that in turn made jakarta.servlet-api (the successor of javax.servlet-api) required for compilation, causing the exception `java.lang.NoClassDefFoundError: jakarta/servlet/ServletContextListener` on start-up.