### PR TITLE
Populate assignTo field from HTTP auth username

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ This is how the tool uses FOLIO's APIs:
 
   notes
   tags
+  users
 
   configurations/entries
 ````
@@ -397,7 +398,11 @@ This is how the tool uses FOLIO's APIs:
     "orders.po-number.item.get",
     "orders.acquisition-methods.collection.get",
     "organizations-storage.organizations.collection.get",
-    "tags.collection.get"
+    "perms.users.get",
+    "tags.collection.get",
+    "usergroups.collection.get",
+    "users.collection.get",
+    "users-bl.collection.get"
   ]
 }
 ```

--- a/README.md
+++ b/README.md
@@ -152,10 +152,11 @@ The startup configuration has parameters controlling FOLIO access, start-up beha
 3) if the provided config value is not a valid number, the default will apply
 
 ## What data are populated to FOLIO
-The tool populates FOLIO Orders and Inventory with data from three different sources:
+The tool populates FOLIO Orders and Inventory with data from four different sources:
 1) The incoming MARC records
 2) Static values defined as configuration parameters
-3) Static values hard-coded in the program.
+3) Static values hard-coded in the program
+4) Authentication data via HTTP Request headers
 
 ### Data from the incoming MARC records
 The tool provides three, slightly different sets of MARC mappings. All three share a basic set of mappings but then extend that with some mappings of their own.
@@ -262,6 +263,25 @@ The desired mapping is selected at startup by setting the parameter `marcMapping
 | IF PHYSICAL                                                  |
 | orderLine.cost.quantityPhysical                              | 1                                            |
 | holdingsRecord.holdingsTypeId                                | The holdings type ID for Physical            |
+
+### Authentication data via HTTP Request headers
+
+If the web server hosting the FOLIO Order import tool performs HTTP authentication, then the logged in user can be set in each order's `assignedTo` field.  To do this, configure the web server to set a request header `X-Remote-User` with value matching the FOLIO username, as below.
+
+```
+  <Location />
+
+                  AuthType Basic
+                  AuthName "Order Import Tool"
+                  AuthLDAPURL "ldap://ldapserver.edu/dc=myuniversity,dc=edu?uid"
+                  AuthBasicProvider ldap
+                  require valid-user
+
+                  RequestHeader set X-Remote-User expr=%{REMOTE_USER}
+                  RequestHeader unset Authorization
+
+                  ...
+```
 
 ## Validation of incoming MARC records
 

--- a/src/main/java/org/olf/folio/order/OrderImport.java
+++ b/src/main/java/org/olf/folio/order/OrderImport.java
@@ -12,6 +12,8 @@ import java.util.Map;
 import java.util.TimeZone;
 import java.util.UUID;
 
+import javax.servlet.http.HttpSession;
+
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -44,6 +46,12 @@ public class OrderImport {
 	private static final SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
 	static {
 		dateFormatter.setTimeZone(TimeZone.getTimeZone("UTC"));
+	}
+
+	private HttpSession session;
+
+	public OrderImport(HttpSession session) {
+		this.session = session;
 	}
 
 	public Results runAnalyzeJob(FileStorageHelper fileStore) throws Exception {
@@ -96,6 +104,7 @@ public class OrderImport {
 			try {
 				Record record = reader.next();
 				MarcToFolio mappedMarc = Config.getMarcMapping(record);
+				mappedMarc.addSessionContext(session);
 				RecordChecker.validateMarcRecord(mappedMarc, outcome);
 				if (!outcome.isSkipped()) {
 					// RECORD VALIDATION PASSED OR SERVICE IS CONFIGURED TO ATTEMPT IMPORT IN ANY CASE

--- a/src/main/java/org/olf/folio/order/OrderService.java
+++ b/src/main/java/org/olf/folio/order/OrderService.java
@@ -53,7 +53,8 @@ public class OrderService {
 		// Run synchronous if just analysis (usually quick)
 		if (analyzeOnly) {
 			try {
-				Results results = new OrderImport().runAnalyzeJob(storage);
+				OrderImport orderImport = new OrderImport(servletRequest.getSession(true));
+				Results results = orderImport.runAnalyzeJob(storage);
 				storage.storeResults(results);
 				return Response.status(Response.Status.OK).entity(results.toJsonString()).build();
 			} catch (Exception e) {
@@ -76,7 +77,8 @@ public class OrderService {
 			// Run asynchronous if actual import
 			new Thread(() -> {
 				try {
-					storage.storeResults(new OrderImport().runImportJob(storage, importResults));
+					OrderImport orderImport = new OrderImport(servletRequest.getSession(true));
+					storage.storeResults(orderImport.runImportJob(storage, importResults));
 				}
 				catch (Exception e) {
 					logger.error("There was a problem in the job thread: " + e.getMessage());

--- a/src/main/java/org/olf/folio/order/controllers/OrderController.java
+++ b/src/main/java/org/olf/folio/order/controllers/OrderController.java
@@ -8,12 +8,22 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.log4j.Logger;
+
 @MultipartConfig
 public class OrderController extends HttpServlet {
 	
+	private static final Logger logger = Logger.getLogger(OrderController.class);
+
 	protected void doGet(HttpServletRequest request,HttpServletResponse response) throws ServletException, IOException {
-		 RequestDispatcher rd = request.getRequestDispatcher("WEB-INF/upload-order.jsp");
-		 rd.forward(request, response);	
+		String username = request.getHeader("X-Remote-User");
+		logger.debug("Maybe got username from session: " + username);
+		if (username != null) {
+			request.getSession().setAttribute("username", username);
+		}
+
+		RequestDispatcher rd = request.getRequestDispatcher("WEB-INF/upload-order.jsp");
+		rd.forward(request, response);	
 	}
 
 }

--- a/src/main/java/org/olf/folio/order/controllers/OrderController.java
+++ b/src/main/java/org/olf/folio/order/controllers/OrderController.java
@@ -15,11 +15,14 @@ public class OrderController extends HttpServlet {
 	
 	private static final Logger logger = Logger.getLogger(OrderController.class);
 
+	// Session attributes
+	public static String SESSION_USERNAME = "username";
+
 	protected void doGet(HttpServletRequest request,HttpServletResponse response) throws ServletException, IOException {
 		String username = request.getHeader("X-Remote-User");
 		logger.debug("Maybe got username from session: " + username);
 		if (username != null) {
-			request.getSession().setAttribute("username", username);
+			request.getSession().setAttribute(SESSION_USERNAME, username);
 		}
 
 		RequestDispatcher rd = request.getRequestDispatcher("WEB-INF/upload-order.jsp");

--- a/src/main/java/org/olf/folio/order/entities/orders/CompositePurchaseOrder.java
+++ b/src/main/java/org/olf/folio/order/entities/orders/CompositePurchaseOrder.java
@@ -26,6 +26,7 @@ public class CompositePurchaseOrder extends FolioEntity {
   public static final String P_ID = "id";
   public static final String P_APPROVED = "approved";
   public static final String P_WORKFLOW_STATUS = "workflowStatus";
+  public static final String P_ASSIGNED_TO = "assignedTo";
   public static final String P_BILL_TO = "billTo";
   public static final String P_COMPOSITE_PO_LINES = "compositePoLines";
 
@@ -47,6 +48,7 @@ public class CompositePurchaseOrder extends FolioEntity {
                     .putId(orderId)
                     .putApproved(V_APPROVED)
                     .putWorkflowStatus(V_OPEN)
+                    .putAssignedTo(mappedMarc.assignedTo())
                     .putBillToIfPresent(mappedMarc.billToUuid())
                     .putCompositePoLines(
                             new JSONArray().put(PoLine.fromMarcRecord(orderId, mappedMarc).asJson())
@@ -85,6 +87,9 @@ public class CompositePurchaseOrder extends FolioEntity {
   }
   public CompositePurchaseOrder putWorkflowStatus(String workflowStatus) {
     return (CompositePurchaseOrder) putString(P_WORKFLOW_STATUS, workflowStatus);
+  }
+  public CompositePurchaseOrder putAssignedTo(String username) {
+    return (CompositePurchaseOrder) putString(P_ASSIGNED_TO, username);
   }
   public CompositePurchaseOrder putBillTo(String billTo) {
     return (CompositePurchaseOrder) putString(P_BILL_TO, billTo);

--- a/src/main/java/org/olf/folio/order/folioapis/FolioData.java
+++ b/src/main/java/org/olf/folio/order/folioapis/FolioData.java
@@ -35,6 +35,7 @@ public class FolioData extends FolioAccess {
   public static final String BUDGETS_PATH = "finance/budgets";
   public static final String BUDGET_EXPENSE_CLASSES_PATH = "finance-storage/budget-expense-classes";
   public static final String TAGS_PATH = "tags";
+  public static final String USERS_PATH = "users";
 
   // NAMES OF ENTITY ARRAYS IN RESPONSE JSON FROM THE APIS
   public static final String INSTANCES_ARRAY = "instances";
@@ -57,6 +58,7 @@ public class FolioData extends FolioAccess {
   public static final String NOTE_TYPES_ARRAY = "noteTypes";
   public static final String CONFIGS_ARRAY = "configs";
   public static final String TAGS_ARRAY = "tags";
+  public static final String USERS_ARRAY = "users";
 
   // CACHING LOOKED UP VALUES
   public static final Map<String,String> organizationCodeToUuid = new HashMap<>();
@@ -76,6 +78,7 @@ public class FolioData extends FolioAccess {
   public static final Map<String,String> fundIdAndFiscalYearIdToBudgetId = new HashMap<>();
   public static final Map<String,String> acquisitionMethodValueToUuid = new HashMap<>();
   public static final Map<String,String> budgetAndExpClassToBudgetExpClassId = new HashMap<>();
+  public static final Map<String,String> usernameToUuid = new HashMap<>();
 
   public static String getNextPoNumberFromOrders() throws Exception {
     return (callApiGet(ORDERS_PO_NUMBER_PATH)).getString("poNumber");
@@ -176,6 +179,14 @@ public class FolioData extends FolioAccess {
             NOTE_TYPES_PATH + "?query=(name==%22" + encode(noteTypeName) + "%22)",
             NOTE_TYPES_ARRAY,
             noteTypeNameToUuid);
+  }
+
+  public static String getUserIdByUsername (String username) throws Exception {
+    return getIdByKey(
+            username,
+            USERS_PATH + "?query=(username==%22" + encode(username) + "%22)",
+            USERS_ARRAY,
+            usernameToUuid);
   }
 
   public static String getAddressIdByName (String addressName) throws Exception {

--- a/src/main/java/org/olf/folio/order/mapping/MarcMapLambda.java
+++ b/src/main/java/org/olf/folio/order/mapping/MarcMapLambda.java
@@ -4,6 +4,7 @@ import javax.servlet.http.HttpSession;
 
 import org.marc4j.marc.Record;
 import org.olf.folio.order.importhistory.RecordResult;
+import org.olf.folio.order.controllers.OrderController;
 import org.olf.folio.order.folioapis.FolioData;
 import org.olf.folio.order.folioapis.ValidationLookups;
 
@@ -78,8 +79,8 @@ public class MarcMapLambda extends MarcToFolio {
   }
 
   public String assignedTo() {
-    logger.info("retrieving username from session: " + this.session.getAttribute("username"));
-    String username = (String)this.session.getAttribute("username");
+    String username = (String)this.session.getAttribute(OrderController.SESSION_USERNAME);
+    logger.debug("retrieving username from session: " + username);
     try {
       return FolioData.getUserIdByUsername(username);
     }

--- a/src/main/java/org/olf/folio/order/mapping/MarcMapLambda.java
+++ b/src/main/java/org/olf/folio/order/mapping/MarcMapLambda.java
@@ -1,12 +1,17 @@
 package org.olf.folio.order.mapping;
 
+import javax.servlet.http.HttpSession;
+
 import org.marc4j.marc.Record;
 import org.olf.folio.order.importhistory.RecordResult;
+import org.olf.folio.order.folioapis.FolioData;
 import org.olf.folio.order.folioapis.ValidationLookups;
 
 public class MarcMapLambda extends MarcToFolio {
   protected static final String OBJECT_CODE           = "o";
   protected static final String PROJECT_CODE          = "r";
+
+  protected HttpSession session;
 
   public MarcMapLambda(Record record) {
     super(record);
@@ -67,4 +72,21 @@ public class MarcMapLambda extends MarcToFolio {
       }
     }
   }
+
+  public void addSessionContext(HttpSession session) {
+    this.session = session;
+  }
+
+  public String assignedTo() {
+    logger.info("retrieving username from session: " + this.session.getAttribute("username"));
+    String username = (String)this.session.getAttribute("username");
+    try {
+      return FolioData.getUserIdByUsername(username);
+    }
+    catch (Exception e) {
+      logger.error("Error retrieving user UUID for username: " + username, e);
+      return null;
+    }
+  }
+
 }

--- a/src/main/java/org/olf/folio/order/mapping/MarcToFolio.java
+++ b/src/main/java/org/olf/folio/order/mapping/MarcToFolio.java
@@ -28,6 +28,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import javax.servlet.http.HttpSession;
+
 import static org.olf.folio.order.mapping.Constants.CONTRIBUTOR_NAME_TYPES_MAP;
 
 public abstract class MarcToFolio {
@@ -1083,6 +1085,14 @@ public abstract class MarcToFolio {
 
   public boolean has (String string) {
     return string != null && !string.isEmpty();
+  }
+
+  public void addSessionContext(HttpSession session) {
+    // noop
+  }
+
+  public String assignedTo() {
+    return null;
   }
 
 }

--- a/src/main/webapp/WEB-INF/web.xml
+++ b/src/main/webapp/WEB-INF/web.xml
@@ -49,4 +49,14 @@
     <listener-class>org.olf.folio.order.listeners.ConfigurationListener</listener-class>
   </listener>
 
+  <session-config>
+    <session-timeout>525600</session-timeout>
+    <cookie-config>
+        <name>folio-order-import-session</name>
+        <path>/</path>
+        <http-only>true</http-only>
+        <secure>true</secure>
+    </cookie-config>
+  </session-config>
+
 </web-app>


### PR DESCRIPTION
We have multiple users accessing this webapp, and want to distinguish who is creating the orders.  The order's "created by" info is tied to the OKAPI user, which is configured globally for the deployment and not helpful.  There is an "assigned to" field in FOLIO orders which can work for this purpose.  

To determine who is using the app, this PR assumes that the web server is using HTTP authentication and passing the username via a particular header.