### PR TITLE
Fix invalid timezone in default import.properties

### DIFF
--- a/import.properties
+++ b/import.properties
@@ -15,6 +15,6 @@ uploadFilePath = /var/tmp/folio-order-import
 onValidationErrors = skipFailed
 onIsbnInvalid = removeIsbn
 
-tzTimeZone = America/Boston
+tzTimeZone = America/New_York
 folioUiUrl = https://folio-snapshot.dev.folio.org/
 


### PR DESCRIPTION
I see this error when starting the app via the docker instructions that use the default import.properties.

>  INFO [main] - onValidationErrors             : skipFailed             
 INFO [main] - onIsbnInvalid                  : removeIsbn             
 INFO [main] - tzTimeZone                     : America/Boston         
 INFO [main] - folioUiUrl                     : https://folio-snapshot.dev.folio.org/
 INFO [main] -  
ERROR [main] - tzTimeZone: Unknown time-zone ID: America/Boston  (https://en.wikipedia.org/wiki/List_of_tz_database_time_zones)
ERROR [main] - FAILED TO START SERVICE: FOUND PROBLEMS WITH ONE OR MORE CONFIGURATION SETTINGS.

Replaced Boston with New York; it's the same timezone.